### PR TITLE
Walker: Fix problem with using "." as source directory

### DIFF
--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -293,7 +293,7 @@ func walk(basePath string, files chan<- file) {
 		}
 		if info.IsDir() {
 			// skip hidden directories like .git
-			if strings.HasPrefix(info.Name(), ".") {
+			if path != basePath && strings.HasPrefix(info.Name(), ".") {
 				return filepath.SkipDir
 			}
 		} else {


### PR DESCRIPTION
Since `.` starts with a dot, it is considered a hidden directory, which means s3deploy doesn't work by default. Most users probably don't run into this because they are syncing `public` or something.