### PR TITLE
Content Type: Ignore short peek caused by EOF

### DIFF
--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -419,7 +419,7 @@ func (d *Deployer) upload(source file, destBucket *s3.Bucket) error {
 	if contentType == "" {
 		const magicSize = 512 // Size that DetectContentType expects
 		peek, err := br.Peek(magicSize)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return err
 		}
 


### PR DESCRIPTION
If you have a file with unknown extension that is less than 512 bytes, you get a spurious error. Ignore it.