### PR TITLE
Add link to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pre-built binaries can be found [here](https://github.com/bep/s3deploy/releases/
  go get -u -v github.com/bep/s3deploy
  ```
  
-Note that `s3deploy` is a perfect tool to use with a continuous integration tool such as [CircleCI](https://circleci.com/). See [this static site](https://github.com/bep/bego.io) for a simple example of automated depoloyment of a Hugo site to Amazon S3 via `s3deploy`.  The most relevant files are [circle.yml](https://github.com/bep/bego.io/blob/master/circle.yml) and [.s3deploy.yml](https://github.com/bep/bego.io/blob/master/.s3deploy.yml).
+Note that `s3deploy` is a perfect tool to use with a continuous integration tool such as [CircleCI](https://circleci.com/). See [this static site](https://github.com/bep/bego.io) for a simple example of automated depoloyment of a Hugo site to Amazon S3 via `s3deploy`.  The most relevant files are [circle.yml](https://github.com/bep/bego.io/blob/master/circle.yml) and [.s3deploy.yml](https://github.com/bep/bego.io/blob/master/.s3deploy.yml). For another example, see [this](https://mostlygeek.com/posts/hugo-circle-s3-hosting/) tutorial that uses s3deploy with CircleCI.
 
 ## Use
 


### PR DESCRIPTION
Adds a link to a blog post that talks about using s3deploy with CircleCI, which gives some ideas and suggestions for how to approach this.

(It's not my tutorial, by the way, but one that I found helpful and one that I think can help people set up s3deploy with CircleCI.)