### PR TITLE
Add AWS region information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,23 @@ Usage of s3deploy:
         number of workers to upload files (default -1)
 ```
 
-**Note:** `key` and `secret` can also be set in environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+### Notes
 
+- The `key` and `secret` command flags can also be set with environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+- The `region` flag is the AWS API name for the region where your bucket resides. See the table below or the [AWS Regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) documentation file for an up-to-date version.
+
+Bucket region | API value | Bucket region | API value
+------------- | --------- | ------------- | ----------
+Canada (Central) | `ca-central-1` | Asia Pacific (Mumbai) | `ap-south-1`
+US East (Ohio) | `us-east-2` | Asia Pacific (Seoul) | `ap-northeast-2`
+US East (N. Virginia) | `us-east-1` | Asia Pacific (Singapore) | `ap-southeast-1`
+US West (N. California) | `us-west-1` | Asia Pacific (Sydney) | `ap-southeast-2`
+US West (Oregon) | `us-west-2` | Asia Pacific (Tokyo) | `ap-northeast-1`
+EU (Frankfurt)  | `eu-central-1` | China (Beijing) | `cn-north-1`
+EU (Ireland) | `eu-west-1` | China (Ningxia) | `cn-northwest-1`
+EU (London) | `eu-west-2`
+EU (Paris) | `eu-west-3`
+South America (São Paulo) | `sa-east-1`
 
 ## Global AWS Configuration
 


### PR DESCRIPTION
This commit adds the AWS SDK names for the different bucket regions to the README file. There's also a link added to the official AWS Doc file for more information and an up-to-date version.

My motivation for this commit is to make the learning curve of s3deploy a little bit smaller. Especially users new to hosting on S3 might not know what values they can/should use with the `region` flag of `s3deploy`.

My hope is that this saves people some Googling and confusion, and make s3deploy a little bit less intimidating.