### PR TITLE
[ADD] Order groups when deploying to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ routes:
       gzip: true   
 ``` 
 
+## Deploy order configuration
+
+Deploy order is important sometimes. For instance, when you want to deploy a SPA (Single Page Application), `index.html` and all those files not versioned must be deployed at the end to avoid problems with missing resources.
+
+To specify a deploy order, add the `order` section to your `.s3deploy.yml` as follows:
+
+```yaml
+routes:
+    # your routes here
+    - ...
+order:
+    - "^notmatchingfile$"
+    - "^index\\.html$"
+```
+
+Order groups work following these points:
+* Rules are written as regular expressions to match files.
+* There is always an implicit order group (present at first position), which contains all files not matched by other order groups.
+* Order in array is the one followed on deploys. In previous example, imagine we have the following files: `test.css`, `test.txt`, `test.html`, `index.html`, and `test.js`. All files except `index.html` will be deployed to S3, and then (once all files are uploaded successfully) `index.html` is deployed.
+* Can be empty groups, it means, regular expressions that does not match any files. In this case, this group is ignored in deploys. In previous example, it corresponds to the first appearing rule (`"^notmatchingfile$"`).
 
 ## Example IAM Policy
 

--- a/lib/deployer_test.go
+++ b/lib/deployer_test.go
@@ -6,26 +6,31 @@
 package lib
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	_ remoteStore = (*testStore)(nil)
+	_ remoteStore = (*testRemoteStore)(nil)
 )
 
 func TestDeploy(t *testing.T) {
 	assert := require.New(t)
-	store, m := newTestStore(0, "")
+	store, m := newTestRemoteStore(0, "")
 	source := testSourcePath()
 	configFile := filepath.Join(source, ".s3deploy.yml")
 
@@ -55,7 +60,7 @@ func TestDeploy(t *testing.T) {
 func TestDeployWithBucketPath(t *testing.T) {
 	assert := require.New(t)
 	root := "my/path"
-	store, m := newTestStore(0, root)
+	store, m := newTestRemoteStore(0, root)
 	source := testSourcePath()
 	configFile := filepath.Join(source, ".s3deploy.yml")
 
@@ -82,9 +87,223 @@ func TestDeployWithBucketPath(t *testing.T) {
 
 }
 
+func TestDeployOrder(t *testing.T) {
+	assert := require.New(t)
+	store, m := newTestRemoteStore(0, "")
+	store.delayMillis = 5
+
+	ls := newTestLocalStore("/mylocalstore",
+		newTestLocalFile(".s3deploy.yml", []byte("my test")),
+		newTestLocalFile("index.html", []byte("<html>s3deploy</html>\n")),
+		newTestLocalFile("ab.txt", []byte("AB\n")),
+		newTestLocalFile("main.css", []byte("ABC")),
+	)
+
+	d := &Deployer{
+		cfg: &Config{
+			BucketName: "example.com",
+			RegionName: "eu-west-1",
+			MaxDelete:  300,
+			Silent:     true,
+			SourcePath: "/mylocalstore",
+			conf: fileConfig{
+				Routes: []*route{
+					&route{
+						Route: "^.+\\.(js|css|svg|ttf)$",
+						Headers: map[string]string{
+							"Cache-Control": "max-age=630720000, no-transform, public",
+						},
+						Gzip: true,
+					},
+					&route{
+						Route: "^.+\\.(png|jpg)$",
+						Headers: map[string]string{
+							"Cache-Control": "max-age=630720000, no-transform, public",
+						},
+						Gzip: true,
+					},
+					&route{
+						Route: "^.+\\.(html|xml|json)$",
+						Gzip:  true,
+					},
+				},
+				Order: []string{
+					"^myemptygroup$",
+					"^index\\.html$",
+				},
+			},
+		},
+		outv:    ioutil.Discard,
+		printer: newPrinter(ioutil.Discard),
+		stats:   &DeployStats{},
+		local:   ls,
+	}
+	d.store = newStore(*d.cfg, store)
+
+	assert.NoError(d.cfg.conf.CompileResources())
+
+	stats, err := d.deploy(context.Background(), runtime.NumCPU())
+	assert.NoError(err)
+	assert.Equal("Deleted 1 of 1, uploaded 3, skipped 1 (80% changed)", stats.Summary())
+
+	indexHTML := m["index.html"]
+	assert.IsType(&osFile{}, indexHTML)
+	headers := indexHTML.(*osFile).Headers()
+	assert.Equal("gzip", headers["Content-Encoding"])
+	assert.Equal("text/html; charset=utf-8", headers["Content-Type"])
+
+	// index.html must be the last one on being uploaded
+	indexStart := store.timeActionPut["index.html"].start
+	assertStartsAfterKeys(t, indexStart, store.timeActionPut, ".s3deploy.yml", "main.css")
+}
+
+func TestDeployOrderErrorOpeningFile(t *testing.T) {
+	assert := require.New(t)
+	store, _ := newTestRemoteStore(0, "")
+	store.delayMillis = 5
+
+	ls := newTestLocalStore("/mylocalstore",
+		newTestLocalFile(".s3deploy.yml", []byte("my test")),
+		newTestLocalFile("index.html", []byte("<html>s3deploy</html>\n")),
+		newTestLocalFile("ab.txt", []byte("AB\n")),
+		newTestLocalFile("main.css", []byte("ABC")).withErrorOpening(true),
+	)
+
+	d := &Deployer{
+		cfg: &Config{
+			BucketName: "example.com",
+			RegionName: "eu-west-1",
+			MaxDelete:  300,
+			Silent:     true,
+			SourcePath: "/mylocalstore",
+			conf: fileConfig{
+				Routes: []*route{
+					&route{
+						Route: "^.+\\.(js|css|svg|ttf)$",
+						Headers: map[string]string{
+							"Cache-Control": "max-age=630720000, no-transform, public",
+						},
+						Gzip: true,
+					},
+					&route{
+						Route: "^.+\\.(png|jpg)$",
+						Headers: map[string]string{
+							"Cache-Control": "max-age=630720000, no-transform, public",
+						},
+						Gzip: true,
+					},
+					&route{
+						Route: "^.+\\.(html|xml|json)$",
+						Gzip:  true,
+					},
+				},
+				Order: []string{
+					"^myemptygroup$",
+					"^index\\.html$",
+				},
+			},
+		},
+		outv:    ioutil.Discard,
+		printer: newPrinter(ioutil.Discard),
+		stats:   &DeployStats{},
+		local:   ls,
+	}
+	d.store = newStore(*d.cfg, store)
+
+	assert.NoError(d.cfg.conf.CompileResources())
+
+	_, err := d.deploy(context.Background(), runtime.NumCPU())
+	assert.Error(err)
+	assert.Contains(err.Error(), "Error opening file")
+
+	assert.Equal(time.Time{}, store.timeActionPut["index.html"].start, "index.html must not be uploaded")
+}
+
+func TestDeleteAfterAllUploadsOnDeploy(t *testing.T) {
+	assert := require.New(t)
+	store, m := newTestRemoteStore(0, "")
+	source := testSourcePath()
+	configFile := filepath.Join(source, ".s3deploy.yml")
+
+	cfg := &Config{
+		BucketName: "example.com",
+		RegionName: "eu-west-1",
+		ConfigFile: configFile,
+		MaxDelete:  300,
+		Silent:     true,
+		SourcePath: source,
+		baseStore:  store,
+	}
+
+	stats, err := Deploy(cfg)
+	assert.NoError(err)
+	assert.Equal("Deleted 1 of 1, uploaded 3, skipped 1 (80% changed)", stats.Summary())
+	assertKeys(t, m, ".s3deploy.yml", "main.css", "index.html", "ab.txt")
+
+	deleteStart := store.timeActionDelete["deleteme.txt"].start
+	assertStartsAfterKeys(t, deleteStart, store.timeActionPut, ".s3deploy.yml", "main.css", "index.html")
+}
+
+func TestGroupLocalFiles(t *testing.T) {
+	assert := require.New(t)
+
+	ls := newTestLocalStore("/mylocalstore",
+		newTestLocalFile(".s3deploy.yml", []byte("my test")),
+		newTestLocalFile("index.html", []byte("<html>s3deploy</html>\n")),
+		newTestLocalFile("ab.txt", []byte("AB\n")),
+		newTestLocalFile("main.css", []byte("ABC")),
+	)
+
+	d := &Deployer{
+		cfg: &Config{
+			conf: fileConfig{
+				Routes: []*route{
+					&route{
+						Route: "^.+\\.(js|css|svg|ttf)$",
+						Headers: map[string]string{
+							"Cache-Control": "max-age=630720000, no-transform, public",
+						},
+						Gzip: true,
+					},
+					&route{
+						Route: "^.+\\.(png|jpg)$",
+						Headers: map[string]string{
+							"Cache-Control": "max-age=630720000, no-transform, public",
+						},
+						Gzip: true,
+					},
+					&route{
+						Route: "^.+\\.(html|xml|json)$",
+						Gzip:  true,
+					},
+				},
+				Order: []string{
+					"^myemptygroup$",
+					"^index\\.html$",
+				},
+			},
+		},
+		outv:    ioutil.Discard,
+		printer: newPrinter(ioutil.Discard),
+		stats:   &DeployStats{},
+		local:   ls,
+	}
+
+	assert.NoError(d.cfg.conf.CompileResources())
+
+	localFilesGroupped, err := d.groupLocalFiles(context.Background(), ls, "/mylocalstore")
+	assert.NoError(err)
+	expectedGroup := [][]string{
+		[]string{"ab.txt", ".s3deploy.yml", "main.css"},
+		[]string{},
+		[]string{"index.html"},
+	}
+	assertGroup(t, expectedGroup, localFilesGroupped)
+}
+
 func TestDeployForce(t *testing.T) {
 	assert := require.New(t)
-	store, _ := newTestStore(0, "")
+	store, _ := newTestRemoteStore(0, "")
 	source := testSourcePath()
 
 	cfg := &Config{
@@ -104,7 +323,7 @@ func TestDeployForce(t *testing.T) {
 
 func TestDeploySourceNotFound(t *testing.T) {
 	assert := require.New(t)
-	store, _ := newTestStore(0, "")
+	store, _ := newTestRemoteStore(0, "")
 	wd, _ := os.Getwd()
 	source := filepath.Join(wd, "thisdoesnotexist")
 
@@ -126,7 +345,7 @@ func TestDeploySourceNotFound(t *testing.T) {
 
 func TestDeployInvalidSourcePath(t *testing.T) {
 	assert := require.New(t)
-	store, _ := newTestStore(0, "")
+	store, _ := newTestRemoteStore(0, "")
 	root := "/"
 
 	if runtime.GOOS == "windows" {
@@ -159,7 +378,7 @@ func TestDeployStoreFailures(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		assert := require.New(t)
 
-		store, _ := newTestStore(i, "")
+		store, _ := newTestRemoteStore(i, "")
 		source := testSourcePath()
 
 		cfg := &Config{
@@ -194,7 +413,7 @@ func TestDeployMaxDelete(t *testing.T) {
 		m[fmt.Sprintf("file%d.css", i)] = &testFile{}
 	}
 
-	store := newTestStoreFrom(m, 0)
+	store := newTestRemoteStoreFrom(m, 0)
 
 	cfg := &Config{
 		BucketName: "example.com",
@@ -217,42 +436,94 @@ func testSourcePath() string {
 	return filepath.Join(wd, "testdata") + "/"
 }
 
-func newTestStore(failAt int, root string) (remoteStore, map[string]file) {
+func newTestRemoteStore(failAt int, root string) (*testRemoteStore, map[string]file) {
 	m := map[string]file{
 		path.Join(root, "ab.txt"):       &testFile{key: path.Join(root, "ab.txt"), etag: `"7b0ded95031647702b8bed17dce7698a"`, size: int64(3)},
 		path.Join(root, "main.css"):     &testFile{key: path.Join(root, "main.css"), etag: `"changed"`, size: int64(27)},
 		path.Join(root, "deleteme.txt"): &testFile{},
 	}
 
-	return newTestStoreFrom(m, failAt), m
+	return newTestRemoteStoreFrom(m, failAt), m
 }
 
-func newTestStoreFrom(m map[string]file, failAt int) remoteStore {
-	return &testStore{m: m, failAt: failAt}
+func newTestRemoteStoreFrom(m map[string]file, failAt int) *testRemoteStore {
+	return &testRemoteStore{
+		m:                m,
+		failAt:           failAt,
+		timeActionPut:    make(map[string]timeActions),
+		timeActionDelete: make(map[string]timeActions),
+	}
 }
 
-type testStore struct {
-	failAt int
-	m      map[string]file
-	remote map[string]file
+type timeActions struct {
+	start time.Time
+	end   time.Time
+}
+
+type testRemoteStore struct {
+	failAt           int
+	delayMillis      time.Duration
+	m                map[string]file
+	remote           map[string]file
+	timeActionPut    map[string]timeActions
+	timeActionDelete map[string]timeActions
 
 	sync.Mutex
 }
 
 func assertKeys(t *testing.T, m map[string]file, keys ...string) {
+	if len(keys) != len(m) {
+		t.Log(m)
+		t.Fatalf("map length mismatch asserting keys: %d vs %d", len(keys), len(m))
+	}
+
 	for _, k := range keys {
 		if _, found := m[k]; !found {
 			t.Fatal("key not found:", k)
 		}
 	}
+}
 
-	if len(keys) != len(m) {
-		t.Log(m)
-		t.Fatalf("map length mismatch: %d vs %d", len(keys), len(m))
+func assertStartsAfterKeys(t *testing.T, start time.Time, ta map[string]timeActions, keys ...string) {
+	for _, k := range keys {
+		if tae, found := ta[k]; !found {
+			t.Fatal("time action not found for key:", k)
+		} else {
+			if start.Before(tae.end) {
+				t.Fatalf("Timestamp %s started before ending %s (timestamp=%s)", start.Format("20060102150405"), k, tae.end.Format("20060102150405"))
+			}
+		}
 	}
 }
 
-func (s *testStore) FileMap(opts ...opOption) (map[string]file, error) {
+func assertGroup(t *testing.T, expected [][]string, found [][]*tmpFile) {
+	if len(expected) != len(found) {
+		t.Log(found)
+		t.Fatalf("expected %d groups, but found %d", len(expected), len(found))
+	}
+
+	for i := range expected {
+		elems := make(map[string]int, len(expected[i]))
+		for _, e := range expected[i] {
+			elems[e]++
+		}
+
+		for _, e := range found[i] {
+			if _, ok := elems[e.relPath]; !ok {
+				t.Fatalf("group %d contains unexpected element %s", i, e.relPath)
+			}
+			elems[e.relPath]--
+			if elems[e.relPath] == 0 {
+				delete(elems, e.relPath)
+			}
+		}
+		for e := range elems {
+			t.Fatalf("group %d does not contain element %s", i, e)
+		}
+	}
+}
+
+func (s *testRemoteStore) FileMap(opts ...opOption) (map[string]file, error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -266,18 +537,27 @@ func (s *testStore) FileMap(opts ...opOption) (map[string]file, error) {
 	return c, nil
 }
 
-func (s *testStore) Put(ctx context.Context, f localFile, opts ...opOption) error {
-	s.Lock()
-	defer s.Unlock()
-
+func (s *testRemoteStore) Put(ctx context.Context, f localFile, opts ...opOption) error {
 	if s.failAt == 2 {
 		return errors.New("fail")
 	}
+	s.Lock()
+	ta := timeActions{
+		start: time.Now(),
+	}
 	s.m[f.Key()] = f
+	s.Unlock()
+	if s.delayMillis > 0 {
+		time.Sleep(s.delayMillis * time.Millisecond)
+	}
+	s.Lock()
+	ta.end = time.Now()
+	s.timeActionPut[f.Key()] = ta
+	s.Unlock()
 	return nil
 }
 
-func (s *testStore) DeleteObjects(ctx context.Context, keys []string, opts ...opOption) error {
+func (s *testRemoteStore) DeleteObjects(ctx context.Context, keys []string, opts ...opOption) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -285,11 +565,138 @@ func (s *testStore) DeleteObjects(ctx context.Context, keys []string, opts ...op
 		return errors.New("fail")
 	}
 	for _, k := range keys {
+		ta := timeActions{
+			start: time.Now(),
+		}
 		delete(s.m, k)
+		if s.delayMillis > 0 {
+			time.Sleep(s.delayMillis * time.Millisecond)
+		}
+		ta.end = time.Now()
+		s.timeActionDelete[k] = ta
 	}
 	return nil
 }
 
-func (s *testStore) Finalize() error {
+func (s *testRemoteStore) Finalize() error {
 	return nil
+}
+
+// Test local store and files
+type testLocalFile struct {
+	*bytes.Reader
+	relPath      string
+	size         int
+	errorOpening bool
+}
+
+func newTestLocalFile(relPath string, content []byte) *testLocalFile {
+	return &testLocalFile{
+		bytes.NewReader(content),
+		relPath,
+		len(content),
+		false,
+	}
+}
+
+func (f *testLocalFile) withErrorOpening(errorOpening bool) *testLocalFile {
+	f.errorOpening = errorOpening
+	return f
+}
+
+func (f testLocalFile) Name() string {
+	return path.Base(f.relPath)
+}
+
+func (f testLocalFile) Size() int64 {
+	return int64(f.size)
+}
+
+func (f testLocalFile) Mode() os.FileMode {
+	return 0777
+}
+
+func (f testLocalFile) ModTime() time.Time {
+	return time.Now()
+}
+
+func (f testLocalFile) IsDir() bool {
+	return false
+}
+
+func (f testLocalFile) Sys() interface{} {
+	return nil
+}
+
+func (f testLocalFile) Close() error {
+	return nil
+}
+
+type testLocalStore struct {
+	root  string
+	files map[string]*testLocalFile
+}
+
+func newTestLocalStore(root string, files ...*testLocalFile) *testLocalStore {
+	m := make(map[string]*testLocalFile, len(files))
+	for _, f := range files {
+		abs := path.Join(root, f.relPath)
+		m[abs] = f
+	}
+	return &testLocalStore{
+		root:  root,
+		files: m,
+	}
+}
+
+func (l *testLocalStore) Walk(root string, walkFn WalkFunc) error {
+	for _, f := range l.files {
+		path := path.Join(root, f.relPath)
+		if err := walkFn(path, f, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *testLocalStore) IsHiddenDir(path string) bool {
+	return strings.HasPrefix(path, ".")
+}
+
+func (l *testLocalStore) IsIgnorableFilename(path string) bool {
+	return path == ".DS_Store"
+}
+
+func (l *testLocalStore) NormaliseName(path string) string {
+	return path
+}
+
+func (l *testLocalStore) Abs(p string) (string, error) {
+	if strings.HasPrefix(p, "/") {
+		return p, nil
+	}
+	return path.Join(l.root, p), nil
+}
+
+func (l *testLocalStore) Rel(basePath, path string) (string, error) {
+	return filepath.Rel(basePath, path)
+}
+
+func (l *testLocalStore) Ext(path string) string {
+	return filepath.Ext(path)
+}
+
+func (l *testLocalStore) ToSlash(path string) string {
+	return filepath.ToSlash(path)
+}
+
+func (l *testLocalStore) Open(path string) (io.ReadCloser, error) {
+	f, ok := l.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	if f.errorOpening {
+		return nil, errors.New("Error opening file")
+	}
+	return f, nil
 }

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -93,5 +93,7 @@ func openTestFile(name string) (*osFile, error) {
 		return nil, err
 	}
 
-	return newOSFile(nil, "", relPath, absPath, fi)
+	tmp := newTmpFile(relPath, absPath, fi.Size())
+	s := newOSStore()
+	return newOSFile(s, nil, "", tmp)
 }

--- a/lib/store.go
+++ b/lib/store.go
@@ -7,7 +7,10 @@ package lib
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"sync"
 	"sync/atomic"
 )
@@ -221,3 +224,24 @@ func chunkStrings(s []string, size int) [][]string {
 
 	return chunks
 }
+
+type localStore interface {
+	Walk(root string, walkFn WalkFunc) error
+	IsHiddenDir(path string) bool
+	IsIgnorableFilename(path string) bool
+	NormaliseName(path string) string
+	Abs(path string) (string, error)
+	Rel(basePath, path string) (string, error)
+	Ext(path string) string
+	ToSlash(path string) string
+	Open(path string) (io.ReadCloser, error)
+}
+
+// SkipDir is used as a return value from WalkFuncs to indicate that
+// the directory named in the call is to be skipped. It is not returned
+// as an error by any function.
+var SkipDir = errors.New("skip this directory")
+
+// WalkFunc is the type of the function called for each file or directory
+// visited by Walk.
+type WalkFunc func(path string, info os.FileInfo, err error) error

--- a/lib/testdata/.s3deploy.yml
+++ b/lib/testdata/.s3deploy.yml
@@ -10,5 +10,3 @@ routes:
       gzip: true
     - route: "^.+\\.(html|xml|json)$"
       gzip: true
-      
-        


### PR DESCRIPTION
### Reason
I wanted to use `s3deploy` to deploy a Single Page Application to S3. On SPAs, the order in which things are deployed is important because you can have inconsistencies. On these cases `index.html` must be the latest file on being uploaded.

Imagine an scenario in which you have a CloudFront distribution pointing to an S3 bucket. As SPA, `index.html` must have `cache=0` to avoid problems with new versions. If `index.html` is not uploaded the latest file, you can have these problematic scenarios:
* Latency uploading to S3: if `index.html` is the first file on being uploaded and other files (dependencies such as CSS or JS) take a while on being updated (maybe because you are also uploading big files), CloudFront can cache resources not present on a request performed during the deploy.
* Errors uploading: if you upload `index.html` first and then an error happens (OS error reading a file or network connectivity), all requests will be pointing to this new file which points to resources that may be are not present.

### What is the goal?
Adding support to order file uploads.

### Approach
A task of obtaining the order groups for all local files is executed (see `groupLocalFiles`) before plan process. This method stores on memory the local files (only indispensable information) that must be processed later. Then, each group is processed sequentially, uploading files present on each group in parallel (in the same way than before).

### Refactoring
In order to make more easy the testing and allowing new local stores on the future (maybe a `tgz` file or similar), a new abstraction of local store has been added to the deploy process.

However, as I don't know if this approach fits with the project's needs, I left previous tests intact. Maybe in the future could be changed to adapt this new approach.

### Testing
Testing has been added for new processes.