### PR TITLE
S3: Add Public ACL flag - default to private.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pre-built binaries can be found [here](https://github.com/bep/s3deploy/releases/
 ```bash
  go get -u -v github.com/bep/s3deploy
  ```
- 
+
  To install on MacOS using Homebrew:
 
  ```bash
@@ -45,6 +45,8 @@ Usage of s3deploy:
     	access key ID for AWS
   -max-delete int
     	maximum number of files to delete per deploy (default 256)
+  -public-access
+        set public ACL on uploaded objects, defaults to private if not set.
   -path string
     	optional bucket sub path
   -quiet
@@ -104,8 +106,8 @@ routes:
          Cache-Control: "max-age=630720000, no-transform, public"
       gzip: false
     - route: "^.+\\.(html|xml|json)$"
-      gzip: true   
-``` 
+      gzip: true
+```
 
 
 ## Example IAM Policy
@@ -136,7 +138,7 @@ routes:
 ```
 
 Replace <bucketname> with your own.
-	
+
 ## CloudFront CDN Cache Invalidation
 
 If you have configured CloudFront CDN in front of your S3 bucket, you can supply the `distribution-id` as a flag. This will make sure to invalidate the cache for the updated files after the deployment to S3. Note that the AWS user must have the needed access rights.

--- a/lib/config.go
+++ b/lib/config.go
@@ -35,7 +35,7 @@ type Config struct {
 
 	NumberOfWorkers int
 	MaxDelete       int
-
+	PublicReadACL bool
 	Verbose bool
 	Silent  bool
 	Force   bool
@@ -68,6 +68,7 @@ func flagsToConfig(f *flag.FlagSet) (*Config, error) {
 	f.StringVar(&cfg.CDNDistributionID, "distribution-id", "", "optional CDN distribution ID for cache invalidation")
 	f.StringVar(&cfg.ConfigFile, "config", ".s3deploy.yml", "optional config file")
 	f.IntVar(&cfg.MaxDelete, "max-delete", 256, "maximum number of files to delete per deploy")
+	f.BoolVar(&cfg.PublicReadACL, "public-access", false, "set public ACL on uploaded objects, defaults to private if not set.")
 	f.BoolVar(&cfg.Force, "force", false, "upload even if the etags match")
 	f.BoolVar(&cfg.Try, "try", false, "trial run, no remote updates")
 	f.BoolVar(&cfg.Verbose, "v", false, "enable verbose logging")

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -22,6 +22,7 @@ func TestFlagsToConfig(t *testing.T) {
 		"-key=mykey",
 		"-secret=mysecret",
 		"-max-delete=42",
+		"-public-access=true",
 		"-path=mypath",
 		"-quiet=true",
 		"-region=myregion",
@@ -39,6 +40,7 @@ func TestFlagsToConfig(t *testing.T) {
 	assert.Equal("mykey", cfg.AccessKey)
 	assert.Equal("mysecret", cfg.SecretKey)
 	assert.Equal(42, cfg.MaxDelete)
+	assert.Equal(true, cfg.PublicReadACL)
 	assert.Equal("mypath", cfg.BucketPath)
 	assert.Equal(true, cfg.Silent)
 	assert.Equal("mysource", cfg.SourcePath)

--- a/lib/deployer_test.go
+++ b/lib/deployer_test.go
@@ -34,6 +34,7 @@ func TestDeploy(t *testing.T) {
 		RegionName: "eu-west-1",
 		ConfigFile: configFile,
 		MaxDelete:  300,
+		PublicReadACL: true,
 		Silent:     true,
 		SourcePath: source,
 		baseStore:  store,

--- a/lib/s3.go
+++ b/lib/s3.go
@@ -23,7 +23,7 @@ type s3Store struct {
 	bucket string
 	r      routes
 	svc    *s3.S3
-
+	publicReadACL bool
 	cfc *cloudFrontClient
 }
 
@@ -59,7 +59,7 @@ func newRemoteStore(cfg Config, logger printer) (*s3Store, error) {
 		}
 	}
 
-	s = &s3Store{svc: s3.New(sess), cfc: cfc, bucket: cfg.BucketName, r: cfg.conf.Routes}
+	s = &s3Store{svc: s3.New(sess), cfc: cfc, publicReadACL: cfg.PublicReadACL, bucket: cfg.BucketName, r: cfg.conf.Routes}
 
 	return s, nil
 
@@ -93,11 +93,17 @@ func (s *s3Store) Put(ctx context.Context, f localFile, opts ...opOption) error 
 		}
 	}
 
+	acl := aws.String("private")
+
+	if s.publicReadACL {
+		acl = aws.String("public-read")
+	}
+
 	_, err := s.svc.PutObjectWithContext(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(s.bucket),
 		Key:           aws.String(f.Key()),
 		Body:          f.Content(),
-		ACL:           aws.String("public-read"),
+		ACL:           acl,
 		ContentLength: aws.Int64(f.Size()),
 	}, withHeaders)
 


### PR DESCRIPTION
AWS recently release a global flag that can be set to the entire account so that S3 new public ACL's won't be allowed
https://docs.aws.amazon.com/AmazonS3/latest/user-guide/block-public-access-account.html

thus resulting in access denied when attempting to use this tool which defaults to set ACL (new ACL) to public

this also ties in the use case for issue: #38 

This PR is for setting by default the ACL to private and explictly setting the public ACL in a flag `-s3-public-acl`

I'm kinda new to GoLang and would be happy to fix anything that is not inline.
 