### PR TITLE
Add line break to uploaded message

### DIFF
--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -162,7 +162,7 @@ func (p print) Printf(format string, a ...interface{}) (n int, err error) {
 }
 
 func (d *Deployer) enqueueUpload(ctx context.Context, f *osFile) {
-	d.Printf("%s (%s) %s ", f.relPath, f.reason, up)
+	d.Printf("%s (%s) %s\n", f.relPath, f.reason, up)
 	select {
 	case <-ctx.Done():
 	case d.filesToUpload <- f:


### PR DESCRIPTION
`s3deploy` has 3 types of output about file handling.

1. upload
1. delete (verbose only)
1. skip (verbose only)

`delete` and `skip` messages has a line break at the end of string.
On the other hand `upload` has whitespace instead of `\n`

I would like to add line breaks `upload` messages.