### PR TITLE
Encode CloudFront invalidation paths

### DIFF
--- a/lib/cloudfront.go
+++ b/lib/cloudfront.go
@@ -102,7 +102,7 @@ func (*cloudFrontClient) pathsToInvalidationBatch(ref string, paths ...string) *
 	}
 	cfpaths := &cloudfront.Paths{}
 	for _, p := range paths {
-		cfpaths.Items = append(cfpaths.Items, aws.String(PathEscapeRFC1738(p)))
+		cfpaths.Items = append(cfpaths.Items, aws.String(pathEscapeRFC1738(p)))
 	}
 
 	qty := int64(len(paths))

--- a/lib/cloudfront.go
+++ b/lib/cloudfront.go
@@ -102,7 +102,7 @@ func (*cloudFrontClient) pathsToInvalidationBatch(ref string, paths ...string) *
 	}
 	cfpaths := &cloudfront.Paths{}
 	for _, p := range paths {
-		cfpaths.Items = append(cfpaths.Items, aws.String(p))
+		cfpaths.Items = append(cfpaths.Items, aws.String(PathEscapeRFC1738(p)))
 	}
 
 	qty := int64(len(paths))

--- a/lib/url.go
+++ b/lib/url.go
@@ -1,0 +1,73 @@
+package lib
+
+// [RFC 1738](https://www.ietf.org/rfc/rfc1738.txt)
+// §2.2
+func shouldEscape(c byte) bool {
+	// alphanum
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return false
+	}
+
+	switch c {
+	case '$', '-', '_', '.', '+', '!', '*', '\'', '(', ')', ',': // Special characters
+		return false
+
+	case '/', '?', ':', '@', '=', '&': // Reserved characters
+		return c == '?'
+	}
+	// Everything else must be escaped.
+	return true
+}
+
+// PathEscapeRFC1738 escapes the string so it can be safely placed
+// inside a URL path segment according to RFC1738.
+// Based on golang native implementation of `url.PathEscape`
+// https://golang.org/src/net/url/url.go?s=7976:8008#L276
+func PathEscapeRFC1738(s string) string {
+	spaceCount, hexCount := 0, 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			hexCount++
+		}
+	}
+
+	if spaceCount == 0 && hexCount == 0 {
+		return s
+	}
+
+	var buf [64]byte
+	var t []byte
+
+	required := len(s) + 2*hexCount
+	if required <= len(buf) {
+		t = buf[:required]
+	} else {
+		t = make([]byte, required)
+	}
+
+	if hexCount == 0 {
+		copy(t, s)
+		for i := 0; i < len(s); i++ {
+			if s[i] == ' ' {
+				t[i] = '+'
+			}
+		}
+		return string(t)
+	}
+
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case shouldEscape(c):
+			t[j] = '%'
+			t[j+1] = "0123456789ABCDEF"[c>>4]
+			t[j+2] = "0123456789ABCDEF"[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}

--- a/lib/url.go
+++ b/lib/url.go
@@ -19,11 +19,11 @@ func shouldEscape(c byte) bool {
 	return true
 }
 
-// PathEscapeRFC1738 escapes the string so it can be safely placed
+// pathEscapeRFC1738 escapes the string so it can be safely placed
 // inside a URL path segment according to RFC1738.
 // Based on golang native implementation of `url.PathEscape`
 // https://golang.org/src/net/url/url.go?s=7976:8008#L276
-func PathEscapeRFC1738(s string) string {
+func pathEscapeRFC1738(s string) string {
 	spaceCount, hexCount := 0, 0
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/lib/url_test.go
+++ b/lib/url_test.go
@@ -28,7 +28,7 @@ func TestPathEscapeRFC1738(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := PathEscapeRFC1738(tc.input)
+		actual := pathEscapeRFC1738(tc.input)
 		assert.Equal(actual, tc.expected)
 	}
 }

--- a/lib/url_test.go
+++ b/lib/url_test.go
@@ -1,0 +1,34 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathEscapeRFC1738(t *testing.T) {
+	assert := require.New(t)
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// should NOT encode
+		{"/path/", "/path/"},
+		{"/path/-/", "/path/-/"},
+		{"/path/_/", "/path/_/"},
+		{"/path/*", "/path/*"},
+		{"/path*", "/path*"},
+		{"/path/*.ext", "/path/*.ext"},
+		{"/path/filename*", "/path/filename*"},
+
+		// should encode
+		{"/path/tilde~file", "/path/tilde%7Efile"}, // https://github.com/bep/s3deploy/issues/46
+		{"/path/世界", "/path/%E4%B8%96%E7%95%8C"},   // non-ascii
+	}
+
+	for _, tc := range testCases {
+		actual := PathEscapeRFC1738(tc.input)
+		assert.Equal(actual, tc.expected)
+	}
+}


### PR DESCRIPTION
### Related issue
#46

### Background

- CloudFont API expects RFC1738-encoded strings as path
  - https://github.com/aws/aws-sdk-go/issues/223
  - [RFC1738](https://www.ietf.org/rfc/rfc1738.txt) (mainly section 2.2.)
- All aws-sdks (not limited to `aws-sdk-go`) do NOT encode path
  - It seems to be specification of aws-sdk
  - Not `aws-sdk-go` but its client should encode paths if necessary
  - https://github.com/aws/aws-sdk-go/issues/223
- Golang's `PathEscape` under `net/url` follows RFC3986 but not RFC1738
  - [source](https://golang.org/src/net/url/url.go?s=7976:8008#L96)
  - [RFC3986](https://www.ietf.org/rfc/rfc3986.txt) (mainly section 2.2. , 2.3.)
  - e.g.) `~` should be encoded according to RFC1738 while allowed to use in the context of RFC3986
- you must implement RFC1738's version of `PathEscape` newly.
  - `PathEscapeRFC1738` is based on `PathEscape` implementation of golang