### PR TITLE
Add Prefix param to ListObjectsPages

### DIFF
--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -234,10 +234,6 @@ func (d *Deployer) plan(ctx context.Context) error {
 
 	// any remote files not found locally should be removed:
 	for key := range remoteFiles {
-		if !strings.HasPrefix(key, d.cfg.BucketPath) {
-			// Not part of this site: Keep!
-			continue
-		}
 		d.enqueueDelete(key)
 	}
 

--- a/lib/s3.go
+++ b/lib/s3.go
@@ -20,11 +20,12 @@ var (
 )
 
 type s3Store struct {
-	bucket string
-	r      routes
-	svc    *s3.S3
+	bucket        string
+	bucketPath    string
+	r             routes
+	svc           *s3.S3
 	publicReadACL bool
-	cfc *cloudFrontClient
+	cfc           *cloudFrontClient
 }
 
 type s3File struct {
@@ -59,7 +60,7 @@ func newRemoteStore(cfg Config, logger printer) (*s3Store, error) {
 		}
 	}
 
-	s = &s3Store{svc: s3.New(sess), cfc: cfc, publicReadACL: cfg.PublicReadACL, bucket: cfg.BucketName, r: cfg.conf.Routes}
+	s = &s3Store{svc: s3.New(sess), cfc: cfc, publicReadACL: cfg.PublicReadACL, bucket: cfg.BucketName, r: cfg.conf.Routes, bucketPath: cfg.BucketPath}
 
 	return s, nil
 
@@ -70,6 +71,7 @@ func (s *s3Store) FileMap(opts ...opOption) (map[string]file, error) {
 
 	err := s.svc.ListObjectsPages(&s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(s.bucketPath),
 	}, func(res *s3.ListObjectsOutput, last bool) (shouldContinue bool) {
 		for _, o := range res.Contents {
 			m[*o.Key] = &s3File{o: o}


### PR DESCRIPTION
Please let me try explaining #42 again.

### Assume a situation
```
.
├── contents
|  └── (index.html)
└── assets
   ├── static-file00001
   ├── static-file00002
   |...
   └── static-file20000
```

- Files in `contents` directory are frequently updated (such as Hugo's output)
- Files in `assets` directory are rarely mutated. But `assets` has 20000 files
  - File sizes do not matter here. but they are a few of bytes.
  - (Number of files matters) 
- Only `contents/index.html` is needed to be uploaded newly.

### Measure execution times
Compared with `s3deploy` and `awscli`

```bash
$ time aws s3 sync contents/ s3://<my-bucket>/contents
upload: contents/index.html to s3://<my-bucket>/contents/index.html
aws s3 sync contents/ s3://<my-bucket>/contents  0.76s user 0.14s system 53% cpu 1.683 total

$ time aws s3 sync contents/ s3://<my-bucket>/contents
upload: contents/index.html to s3://<my-bucket>/contents/index.html
aws s3 sync contents/ s3://<my-bucket>/contents  1.11s user 0.47s system 55% cpu 2.842 total

$ time aws s3 sync contents/ s3://<my-bucket>/contents
upload: contents/index.html to s3://<my-bucket>/contents/index.html
aws s3 sync contents/ s3://<my-bucket>/contents  0.94s user 0.22s system 61% cpu 1.883 total

```

```bash
$ ./s3deploy \
  -region=<my-region> \
  -bucket=<my-bucket>\
  -key=$AWS_ID \
  -secret=$AWS_SECRET \
  -source=contents \
  -path=contents\
  -v

s3deploy v2, commit none, built at unknown
index.html (not found) ↑
Total in 9.74 seconds
Deleted 0 of 0, uploaded 1, skipped 0 (100% changed)


$ ./s3deploy \
  -region=<my-region> \
  -bucket=<my-bucket>\
  -key=$AWS_ID \
  -secret=$AWS_SECRET \
  -source=contents \
  -path=contents\
  -v

s3deploy v2, commit none, built at unknown
index.html (not found) ↑
Total in 8.82 seconds
Deleted 0 of 0, uploaded 1, skipped 0 (100% changed)

$ ./s3deploy \
  -region=<my-region> \
  -bucket=<my-bucket>\
  -key=$AWS_ID \
  -secret=$AWS_SECRET \
  -source=contents \
  -path=contents\
  -v

s3deploy v2, commit none, built at unknown
index.html (not found) ↑
Total in 9.69 seconds
Deleted 0 of 0, uploaded 1, skipped 0 (100% changed)

```

Under the condition, `s3deploy` is ~10 times slower than `awscli`

### Study bottleneck
I found the main cause `ListObjectsPages` in `s3.go` by changing

```go
func (s *s3Store) FileMap(opts ...opOption) (map[string]file, error) {
	m := make(map[string]file)

	from := time.Now()  // Add
	err := s.svc.ListObjectsPages(&s3.ListObjectsInput{
		Bucket: aws.String(s.bucket),
	}, func(res *s3.ListObjectsOutput, last bool) (shouldContinue bool) {
		for _, o := range res.Contents {
			m[*o.Key] = &s3File{o: o}
		}
		return true
	})

	fmt.Println("[Execution time] ListObjectsPages: ", time.Since(from))  // Add

	if err != nil {
		return nil, err
	}

	return m, nil
}
```

The output was
```
$ ./s3deploy \
  -region=<my-region> \
  -bucket=<my-bucket>\
  -key=$AWS_ID \
  -secret=$AWS_SECRET \
  -source=contents \
  -path=contents\
  -v

s3deploy v2, commit none, built at unknown
[Execution time] ListObjectsPages: 12.67898647s
index.html (not found) ↑
Total in 12.79 seconds
Deleted 0 of 0, uploaded 1, skipped 0 (100% changed)
```
This process took up about 99% of total execution time.

Therefore I checked [a corresponding part](https://github.com/aws/aws-cli/blob/e46523aea98586768d68d09302a97593a88c45a9/awscli/customizations/s3/filegenerator.py#L322) of `awscli` implementation.

Difference between them is if it uses `prefix` as option or not.
If not, the number of requests to list objects are increased because unused remote objects are also targeted.

### Fix
- Use `BucketPath` as `Prefix` param
  - As far as I searched, there is no doc which says `ListObjectsPages`'s behaviour when set `Prefix: ""` (default value in the implementation)
    - I confirmed that its behaviour same as when `Prefix` is not set.
    - `awscli`'s `list_objects` (in python) also uses an empty string as `prefix` option
- Remove `HasPrefix` condition from `deployer.go`
  - `remoteFiles` have only keys with prefix


### Check Result
```bash
$ time ./s3deploy \
  -region=<my-region> \
  -bucket=<my-bucket>\
  -key=$AWS_ID \
  -secret=$AWS_SECRET \
  -source=contents \
  -path=contents\
  -v

s3deploy v2, commit none, built at unknown
[Execution time] ListObjectsPages:  754.809774ms
index.html (not found) ↑
Total in 0.86 seconds
Deleted 0 of 0, uploaded 1, skipped 0 (100% changed)
./s3deploy -region=<my-region> -bucket=<my-bucket>     -v  0.11s user 0.03s system 16% cpu 0.897 total

```