### PR TITLE
Add 'dotallowlist' to .s3deploy.yml config file

### DIFF
--- a/lib/files.go
+++ b/lib/files.go
@@ -219,6 +219,7 @@ func newOSFile(routes routes, targetRoot, relPath, absPath string, fi os.FileInf
 }
 
 type routes []*route
+type filen []*string
 
 func (r routes) get(path string) *route {
 
@@ -236,6 +237,7 @@ func (r routes) get(path string) *route {
 // read config from .s3deploy.yml if found.
 type fileConfig struct {
 	Routes routes `yaml:"routes"`
+	DotAllowlist filen `yaml:"dotallowlist"`
 }
 
 type route struct {


### PR DESCRIPTION
Fixes https://github.com/bep/s3deploy/issues/53

Example addition to config file:

```yaml
dotallowlist:
  - .well-known
```

Warning: I don't know Golang.  This code appears to work, but may not be
idiomatic Golang.