### PR TITLE
feat: allow passing canned acl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Note that `s3deploy` is a perfect tool to use with a continuous integration tool
 ## Use
 
 ```bash
-Usage of s3deploy:
+Usage of ./s3deploy:
   -V	print version and exit
+  -acl string
+    	provide an ACL for uploaded objects. to make objects public, set to 'public-read'. all possible values are listed here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl (default "private")
   -bucket string
     	destination bucket name on AWS
   -config string
@@ -44,10 +46,10 @@ Usage of s3deploy:
     	access key ID for AWS
   -max-delete int
     	maximum number of files to delete per deploy (default 256)
-  -public-access
-        set public ACL on uploaded objects, defaults to private if not set.
   -path string
     	optional bucket sub path
+  -public-access
+    	DEPRECATED: please set -acl='public-read'
   -quiet
     	enable silent mode
   -region string

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -22,7 +22,7 @@ func TestFlagsToConfig(t *testing.T) {
 		"-key=mykey",
 		"-secret=mysecret",
 		"-max-delete=42",
-		"-public-access=true",
+		"-acl=public-read",
 		"-path=mypath",
 		"-quiet=true",
 		"-region=myregion",
@@ -40,12 +40,29 @@ func TestFlagsToConfig(t *testing.T) {
 	assert.Equal("mykey", cfg.AccessKey)
 	assert.Equal("mysecret", cfg.SecretKey)
 	assert.Equal(42, cfg.MaxDelete)
-	assert.Equal(true, cfg.PublicReadACL)
+	assert.Equal("public-read", cfg.ACL)
 	assert.Equal("mypath", cfg.BucketPath)
 	assert.Equal(true, cfg.Silent)
 	assert.Equal("mysource", cfg.SourcePath)
 	assert.Equal(true, cfg.Try)
 	assert.Equal("myregion", cfg.RegionName)
 	assert.Equal("mydistro", cfg.CDNDistributionID)
+}
 
+func TestSetAclAndPublicAccessFlag(t *testing.T) {
+	assert := require.New(t)
+	flags := flag.NewFlagSet("test", flag.PanicOnError)
+	args := []string{
+		"-bucket=mybucket",
+		"-acl=public-read",
+		"-public-access=true",
+	}
+
+	cfg, err := flagsToConfig(flags)
+	assert.NoError(err)
+	assert.NoError(flags.Parse(args))
+
+	check_err := cfg.check()
+	assert.Error(check_err)
+	assert.Contains(check_err.Error(), "you passed a value for the flags public-access and acl")
 }

--- a/lib/deployer_test.go
+++ b/lib/deployer_test.go
@@ -34,7 +34,7 @@ func TestDeploy(t *testing.T) {
 		RegionName: "eu-west-1",
 		ConfigFile: configFile,
 		MaxDelete:  300,
-		PublicReadACL: true,
+		ACL:        "public-read",
 		Silent:     true,
 		SourcePath: source,
 		baseStore:  store,

--- a/lib/s3_test.go
+++ b/lib/s3_test.go
@@ -1,0 +1,73 @@
+package lib
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRemoteStoreNoAclProvided(t *testing.T) {
+	assert := require.New(t)
+
+	cfg := Config{
+		BucketName: "example.com",
+		RegionName: "us-east-1",
+		ACL:        "",
+		Silent:     true,
+	}
+
+	s, err := newRemoteStore(cfg, newPrinter(ioutil.Discard))
+	assert.NoError(err)
+
+	assert.Equal(s.acl, "private")
+}
+
+func TestNewRemoteStoreAclProvided(t *testing.T) {
+	assert := require.New(t)
+
+	cfg := Config{
+		BucketName: "example.com",
+		RegionName: "us-east-1",
+		ACL:        "public-read",
+		Silent:     true,
+	}
+
+	s, err := newRemoteStore(cfg, newPrinter(ioutil.Discard))
+	assert.NoError(err)
+
+	assert.Equal(s.acl, "public-read")
+}
+
+func TestNewRemoteStoreOtherCannedAclProvided(t *testing.T) {
+	assert := require.New(t)
+
+	cfg := Config{
+		BucketName: "example.com",
+		RegionName: "us-east-1",
+		ACL:        "bucket-owner-full-control",
+		Silent:     true,
+	}
+
+	s, err := newRemoteStore(cfg, newPrinter(ioutil.Discard))
+	assert.NoError(err)
+
+	assert.Equal(s.acl, "bucket-owner-full-control")
+}
+
+func TestNewRemoteStoreDeprecatedPublicReadACLFlaglProvided(t *testing.T) {
+	assert := require.New(t)
+
+	cfg := Config{
+		BucketName:    "example.com",
+		RegionName:    "us-east-1",
+		PublicReadACL: true,
+		ACL:           "",
+		Silent:        true,
+	}
+
+	s, err := newRemoteStore(cfg, newPrinter(ioutil.Discard))
+	assert.NoError(err)
+
+	assert.Equal(s.acl, "public-read")
+}


### PR DESCRIPTION
This PR adds support for passing arbitrary canned ACL values to the S3 client.

Today, users can only pass `private` or `public-read` ACLs to the S3 client (via the `-public-access` flag). However, in my use case, I need to use the `bucket-owner-full-control` [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl). As written (as far as I can tell), I cannot do this today.

For discussion: this PR suggests deprecating the `-public-access` flag in favor of the more flexible `acl` flag. See inline comment for details.

Thanks for your time & consideration!

Fixes #63