### PR TITLE
Add 'ignore' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Usage of ./s3deploy:
   -force
     	upload even if the etags match
   -h	help
+  -ignore string
+    	regexp pattern for ignoring files
   -key string
     	access key ID for AWS
   -max-delete int

--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -233,7 +233,12 @@ func (d *Deployer) plan(ctx context.Context) error {
 	close(d.filesToUpload)
 
 	// any remote files not found locally should be removed:
+	// except for ignored files
 	for key := range remoteFiles {
+		if d.cfg.shouldIgnoreRemote(key) {
+			fmt.Fprintf(d.outv, "%s ignored …\n", key)
+			continue
+		}
 		d.enqueueDelete(key)
 	}
 
@@ -273,6 +278,11 @@ func (d *Deployer) walk(ctx context.Context, basePath string, files chan<- *osFi
 		if err != nil {
 			return err
 		}
+
+		if d.cfg.shouldIgnoreLocal(rel) {
+			return nil
+		}
+
 		f, err := newOSFile(d.cfg.conf.Routes, d.cfg.BucketPath, rel, abs, info)
 		if err != nil {
 			return err


### PR DESCRIPTION
Via 'ignore' flag, you can exclude local files and keep remote objects stale that are matched with regexp.


Usage example:
```
s3deploy \
    -source=public/ \
    -bucket=example.com \
    -region=eu-west-1 \
    -key=$AWS_ACCESS_KEY_ID \
    -secret=$AWS_SECRET_ACCESS_KEY \
    -ignore="^unsynced-dir/.*$" \
    -v
```

Number of ignored items is not added to any stats count.

UPDATED
Close #33 