### PR TITLE
Allow multiple distribution-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Note that `s3deploy` is a perfect tool to use with a continuous integration tool
 ## Use
 
 ```bash
-Usage of ./s3deploy:
   -V	print version and exit
   -acl string
     	provide an ACL for uploaded objects. to make objects public, set to 'public-read'. all possible values are listed here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl (default "private")
@@ -37,8 +36,8 @@ Usage of ./s3deploy:
     	destination bucket name on AWS
   -config string
     	optional config file (default ".s3deploy.yml")
-  -distribution-id string
-    	optional CDN distribution ID for cache invalidation
+  -distribution-id value
+    	optional CDN distribution ID for cache invalidation, repeat flag for multiple distributions
   -force
     	upload even if the etags match
   -h	help

--- a/lib/cloudfront_test.go
+++ b/lib/cloudfront_test.go
@@ -61,7 +61,6 @@ func TestReduceInvalidationPaths(t *testing.T) {
 	assert.Equal([]string{"/*"}, normalized)
 	normalized = client.normalizeInvalidationPaths("root", 5, true, rootPlusManyInDifferentFoldersNested...)
 	assert.Equal([]string{"/root/*"}, normalized)
-
 }
 
 func TestDetermineRootAndSubPath(t *testing.T) {
@@ -80,7 +79,6 @@ func TestDetermineRootAndSubPath(t *testing.T) {
 	check("/temp/forsale/", "temp", "/forsale", "temp")
 	check("root", "root", "/", "root")
 	check("root", "/root", "/", "root")
-
 }
 
 func TestPathsToInvalidationBatch(t *testing.T) {
@@ -99,13 +97,13 @@ func TestNewCloudFrontClient(t *testing.T) {
 	assert := require.New(t)
 	s := mock.Session
 	c, err := newCloudFrontClient(s, newPrinter(ioutil.Discard), Config{
-		CDNDistributionID: "12345",
-		Force:             true,
-		BucketPath:        "/mypath",
+		CDNDistributionIDs: Strings{"12345"},
+		Force:              true,
+		BucketPath:         "/mypath",
 	})
 	assert.NoError(err)
 	assert.NotNil(c)
-	assert.Equal("12345", c.distributionID)
+	assert.Equal("12345", c.distributionIDs[0])
 	assert.Equal("/mypath", c.bucketPath)
 	assert.Equal(true, c.force)
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -15,6 +15,17 @@ import (
 	"strings"
 )
 
+type Strings []string
+
+func (i *Strings) String() string {
+	return strings.Join(*i, ",")
+}
+
+func (i *Strings) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 // Config configures a deployment.
 type Config struct {
 	conf fileConfig
@@ -29,8 +40,8 @@ type Config struct {
 	BucketPath string
 	RegionName string
 
-	// When set, will invalidate the CDN cache for the updated files.
-	CDNDistributionID string
+	// When set, will invalidate the CDN cache(s) for the updated files.
+	CDNDistributionIDs Strings
 
 	// Optional configFile
 	ConfigFile string
@@ -70,7 +81,7 @@ func flagsToConfig(f *flag.FlagSet) (*Config, error) {
 	f.StringVar(&cfg.BucketName, "bucket", "", "destination bucket name on AWS")
 	f.StringVar(&cfg.BucketPath, "path", "", "optional bucket sub path")
 	f.StringVar(&cfg.SourcePath, "source", ".", "path of files to upload")
-	f.StringVar(&cfg.CDNDistributionID, "distribution-id", "", "optional CDN distribution ID for cache invalidation")
+	f.Var(&cfg.CDNDistributionIDs, "distribution-id", "optional CDN distribution ID for cache invalidation, repeat flag for multiple distributions")
 	f.StringVar(&cfg.ConfigFile, "config", ".s3deploy.yml", "optional config file")
 	f.IntVar(&cfg.MaxDelete, "max-delete", 256, "maximum number of files to delete per deploy")
 	f.BoolVar(&cfg.PublicReadACL, "public-access", false, "DEPRECATED: please set -acl='public-read'")

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -47,7 +47,7 @@ func TestFlagsToConfig(t *testing.T) {
 	assert.Equal("mysource", cfg.SourcePath)
 	assert.Equal(true, cfg.Try)
 	assert.Equal("myregion", cfg.RegionName)
-	assert.Equal("mydistro", cfg.CDNDistributionID)
+	assert.Equal(Strings{"mydistro"}, cfg.CDNDistributionIDs)
 	assert.Equal("^ignored-prefix.*", cfg.Ignore)
 }
 

--- a/lib/s3.go
+++ b/lib/s3.go
@@ -53,7 +53,7 @@ func newRemoteStore(cfg Config, logger printer) (*s3Store, error) {
 		return nil, err
 	}
 
-	if cfg.CDNDistributionID != "" {
+	if len(cfg.CDNDistributionIDs) > 0 {
 		cfc, err = newCloudFrontClient(sess, logger, cfg)
 		if err != nil {
 			return nil, err
@@ -70,7 +70,6 @@ func newRemoteStore(cfg Config, logger printer) (*s3Store, error) {
 	s = &s3Store{svc: s3.New(sess), cfc: cfc, acl: acl, bucket: cfg.BucketName, r: cfg.conf.Routes, bucketPath: cfg.BucketPath}
 
 	return s, nil
-
 }
 
 func (s *s3Store) FileMap(opts ...opOption) (map[string]file, error) {
@@ -93,7 +92,6 @@ func (s *s3Store) FileMap(opts ...opOption) (map[string]file, error) {
 }
 
 func (s *s3Store) Put(ctx context.Context, f localFile, opts ...opOption) error {
-
 	headers := f.Headers()
 
 	withHeaders := func(r *request.Request) {


### PR DESCRIPTION
This allows multiple values in `distribution-id`; add by repeating the flag with new values e.g.:

```bash
s3deploy -bucket=mybucket -distribution-id=abcd -distribution-id=efgh
```

Fixes #142
