### PR TITLE
Allow overriding default AWS endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The list of flags from running `s3deploy -h`:
     optional config file (default ".s3deploy.yml")
 -distribution-id value
     optional CDN distribution ID for cache invalidation, repeat flag for multiple distributions
+-endpoint-url url
+	optional AWS endpoint URL override
 -force
     upload even if the etags match
 -h	help

--- a/lib/config.go
+++ b/lib/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	// When set, will invalidate the CDN cache(s) for the updated files.
 	CDNDistributionIDs Strings
 
+	// When set, will override the default AWS endpoint.
+	EndpointURL string
+
 	// Optional configFile
 	ConfigFile string
 
@@ -244,6 +247,7 @@ func flagsToConfig(f *flag.FlagSet) *Config {
 	f.StringVar(&cfg.BucketPath, "path", "", "optional bucket sub path")
 	f.StringVar(&cfg.SourcePath, "source", ".", "path of files to upload")
 	f.Var(&cfg.CDNDistributionIDs, "distribution-id", "optional CDN distribution ID for cache invalidation, repeat flag for multiple distributions")
+	f.StringVar(&cfg.EndpointURL, "endpoint-url", "", "optional endpoint URL")
 	f.StringVar(&cfg.ConfigFile, "config", ".s3deploy.yml", "optional config file")
 	f.IntVar(&cfg.MaxDelete, "max-delete", 256, "maximum number of files to delete per deploy")
 	f.BoolVar(&cfg.PublicReadACL, "public-access", false, "DEPRECATED: please set -acl='public-read'")

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -27,6 +27,7 @@ func TestConfigFromArgs(t *testing.T) {
 		"-quiet=true",
 		"-region=myregion",
 		"-source=mysource",
+		"-endpoint-url=http://localhost:9000",
 		"-distribution-id=mydistro1",
 		"-distribution-id=mydistro2",
 		"-ignore=^ignored-prefix.*",
@@ -46,6 +47,7 @@ func TestConfigFromArgs(t *testing.T) {
 	c.Assert(cfg.BucketPath, qt.Equals, "mypath")
 	c.Assert(cfg.Silent, qt.Equals, true)
 	c.Assert(cfg.SourcePath, qt.Equals, "mysource")
+	c.Assert(cfg.EndpointURL, qt.Equals, "http://localhost:9000")
 	c.Assert(cfg.Try, qt.Equals, true)
 	c.Assert(cfg.RegionName, qt.Equals, "myregion")
 	c.Assert(cfg.CDNDistributionIDs, qt.DeepEquals, Strings{"mydistro1", "mydistro2"})

--- a/lib/session.go
+++ b/lib/session.go
@@ -13,10 +13,21 @@ import (
 )
 
 func newAWSConfig(cfg *Config) (aws.Config, error) {
-	return aws.Config{
+	config := aws.Config{
 		Region:      cfg.RegionName,
 		Credentials: createCredentials(cfg),
-	}, nil
+	}
+
+	if cfg.EndpointURL != "" {
+		resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				URL: cfg.EndpointURL,
+			}, nil
+		})
+		config.EndpointResolverWithOptions = resolver
+	}
+
+	return config, nil
 }
 
 func createCredentials(cfg *Config) aws.CredentialsProvider {

--- a/lib/session_test.go
+++ b/lib/session_test.go
@@ -1,0 +1,26 @@
+package lib
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewAWSConfigWithCustomEndpoint(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		BucketName:  "example.com",
+		RegionName:  "us-east-1",
+		EndpointURL: "http://localhost:9000",
+		Silent:      true,
+	}
+
+	awsCfg, err := newAWSConfig(cfg)
+	c.Assert(err, qt.IsNil)
+
+	endpoint, err := awsCfg.EndpointResolverWithOptions.ResolveEndpoint("s3", "us-east-1")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert("http://localhost:9000", qt.Equals, endpoint.URL)
+}


### PR DESCRIPTION
Adds `endpoint-url` option, which can be used to override endpoint URL for S3 client.

Setting custom endpoint URL allows you to use s3deploy for Cloudflare R2 deployments via S3 Compatibility API.

```
s3deploy -endpoint-url https://<ACCOUNT_ID>.r2.cloudflarestorage.com -region auto ...
```