### PR TITLE
release: Publish a tar.gz archive for MacOS

### DIFF
--- a/hugoreleaser.toml
+++ b/hugoreleaser.toml
@@ -113,7 +113,7 @@ archive_alias_replacements = {}
             goarch = "amd64"
 
 [[archives]]
-    paths = ["builds/unix/**"]
+    paths = ["builds/{unix,macos}/**"]
 [[archives]]
     paths = ["builds/macos/**"]
     [archives.archive_settings]


### PR DESCRIPTION
In addition to the `.pkg` archive.

Closes #497
